### PR TITLE
configurable target logger name

### DIFF
--- a/sqlformatter.py
+++ b/sqlformatter.py
@@ -39,9 +39,10 @@ class LogDb:
     def __init__(self):
         self.handler = None
         self.propagate = None
+        self.logger_name = 'django.db.backends'
 
     def __call__(self, **options):
-        logger = logging.getLogger('django.db.backends')
+        logger = logging.getLogger(self.logger_name)
 
         if self.handler is None:
             # Enable


### PR DESCRIPTION
I wanted to use this in a project that does not involve django.  Now you can configure the logger like so:

``` py
import logging
from sqlformatter import logdb

LOGGER = logging.getLogger('cool_logger')
# Use our logger
logdb.logger_name = LOGGER.name
```
