### PR TITLE
Bump sqlparse version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Pygments==1.6
-sqlparse==0.1.11
+sqlparse==0.3.1


### PR DESCRIPTION
Django 3.1.1 requires sqlparse >= 0.2.2. Installing sqlparse on a project using Django 3.1+ will return the error below:


```bash
Installing collected packages: sqlparse, sqlformatter
  Attempting uninstall: sqlparse
    Found existing installation: sqlparse 0.3.1
    Uninstalling sqlparse-0.3.1:
      Successfully uninstalled sqlparse-0.3.1
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

django 3.1.1 requires sqlparse>=0.2.2, but you'll have sqlparse 0.1.11 which is incompatible.
django-debug-toolbar 2.2 requires sqlparse>=0.2.0, but you'll have sqlparse 0.1.11 which is incompatible.
Successfully installed sqlformatter-1.3 sqlparse-0.1.11
```

I've been using my fork for a couple of days and everything looks good.
